### PR TITLE
feat: Add new tests for live iso testing

### DIFF
--- a/testcases/ubuntu-mate/24.04/i18n/en_US
+++ b/testcases/ubuntu-mate/24.04/i18n/en_US
@@ -51,6 +51,7 @@ text_installation_select_your_timezone_title="Select your timezone"
 
 text_installation_ready_to_install_title="Ready to install"
 
+text_firefox_welcome_to_firefox="Welcome to Firefox"
 
 text_installation_complete_body1="Ubuntu-MATE 24.04 LTS is installed and ready to use"
 text_installation_complete_body2="Any changes you make will not be saved"

--- a/testcases/ubuntu-mate/24.04/test_boot_to_live_environment
+++ b/testcases/ubuntu-mate/24.04/test_boot_to_live_environment
@@ -40,10 +40,6 @@ function test_open_terminal_capture_xrandr() {
     qt_send_key_combo "ctrl-alt-t"
     qt_screenshot_ppm "$FUNCNAME"
     qt_wait_for_seconds 1
-    # Maximize the window
-    qt_send_key_combo "alt-space"
-    qt_send_key "x"
-    qt_wait_for_seconds 1
     # Put something vaguely interesting useful in the terminal
     qt_send_string_return "xrandr"
     qt_send_string_return "lsb_release -a"

--- a/testcases/ubuntu-mate/24.04/test_boot_to_live_environment
+++ b/testcases/ubuntu-mate/24.04/test_boot_to_live_environment
@@ -1,0 +1,78 @@
+# Boot to live environment
+########################################################################################
+#                                                                                      #
+#        Name: test_boot_to_live_environment                                           #
+#      Author: Alan Pope                                                               #
+#        Date: 2024-05-13                                                              #
+#     Version: 1                                                                       #
+# Description: Boot to the graphical desktop                                           #
+#                                                                                      #
+########################################################################################
+
+function test_setup() {
+    # No setup required
+    echo "No setup required"
+}
+
+function test_post_boot_grub() {
+    # Wait a while for EUFI or BIOS to pass
+    # We could skip having this function, but it's nice to have
+    # So we have the opportunity to click that stupid dialog
+    qt_wait_for_seconds 10
+    # Wait for the grub menu
+    qt_wait_for_text "$FUNCNAME" "$text_console_gnu_grub" 5 5
+    qt_screenshot_ppm "$FUNCNAME"
+    # Press enter on the 'Try or install Ubuntu' GRUB option
+    qt_send_key "return"
+}
+
+function test_installer_initial_load() {
+    # Wait for the installer to load
+    # Takes a while initially to get started so we give it 10 loads of 30 seconds
+    qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_title" 10 30
+    qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_body" 10 3
+    qt_send_key_combo "alt-f4"
+    qt_wait_for_seconds 1
+}
+
+function test_open_terminal_capture_xrandr() {
+    # Open a terminal
+    qt_send_key_combo "ctrl-alt-t"
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_wait_for_seconds 1
+    # Maximize the window
+    qt_send_key_combo "alt-space"
+    qt_send_key "x"
+    qt_wait_for_seconds 1
+    # Put something vaguely interesting useful in the terminal
+    qt_send_string_return "xrandr"
+    qt_send_string_return "lsb_release -a"
+    qt_send_string_return "uname -a"
+    qt_wait_for_seconds 1
+    # Get a pretty screenshot
+    qt_screenshot_ppm "$FUNCNAME"
+    # Close the terminal
+    qt_send_key_combo "ctrl-shift-q"
+}
+
+function test_launch_firefox {
+    # Launch Firefox
+    qt_send_key_combo "meta_l"
+    qt_send_string_return "firefox"
+    qt_wait_for_text "$FUNCNAME" "$text_firefox_welcome_to_firefox" 10 5
+    qt_send_key_combo "alt-f4"
+}
+
+function test_power_off_vm() {
+    # send power off
+    qt_poweroff_vm
+}
+
+function test_boot_to_live_environment() {
+    test_setup
+    test_post_boot_grub
+    test_installer_initial_load
+    test_open_terminal_capture_xrandr
+    test_launch_firefox
+    test_power_off_vm
+}

--- a/testcases/ubuntu-mate/daily-live/test_boot_to_live_environment
+++ b/testcases/ubuntu-mate/daily-live/test_boot_to_live_environment
@@ -40,10 +40,6 @@ function test_open_terminal_capture_xrandr() {
     qt_send_key_combo "ctrl-alt-t"
     qt_screenshot_ppm "$FUNCNAME"
     qt_wait_for_seconds 1
-    # Maximize the window
-    qt_send_key_combo "alt-space"
-    qt_send_key "x"
-    qt_wait_for_seconds 1
     # Put something vaguely interesting useful in the terminal
     qt_send_string_return "xrandr"
     qt_send_string_return "lsb_release -a"

--- a/testcases/ubuntu-mate/daily-live/test_boot_to_live_environment
+++ b/testcases/ubuntu-mate/daily-live/test_boot_to_live_environment
@@ -1,0 +1,78 @@
+# Boot to live environment
+########################################################################################
+#                                                                                      #
+#        Name: test_boot_to_live_environment                                           #
+#      Author: Alan Pope                                                               #
+#        Date: 2024-05-13                                                              #
+#     Version: 1                                                                       #
+# Description: Boot to the graphical desktop                                           #
+#                                                                                      #
+########################################################################################
+
+function test_setup() {
+    # No setup required
+    echo "No setup required"
+}
+
+function test_post_boot_grub() {
+    # Wait a while for EUFI or BIOS to pass
+    # We could skip having this function, but it's nice to have
+    # So we have the opportunity to click that stupid dialog
+    qt_wait_for_seconds 10
+    # Wait for the grub menu
+    qt_wait_for_text "$FUNCNAME" "$text_console_gnu_grub" 5 5
+    qt_screenshot_ppm "$FUNCNAME"
+    # Press enter on the 'Try or install Ubuntu' GRUB option
+    qt_send_key "return"
+}
+
+function test_installer_initial_load() {
+    # Wait for the installer to load
+    # Takes a while initially to get started so we give it 10 loads of 30 seconds
+    qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_title" 10 30
+    qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_body" 10 3
+    qt_send_key_combo "alt-f4"
+    qt_wait_for_seconds 1
+}
+
+function test_open_terminal_capture_xrandr() {
+    # Open a terminal
+    qt_send_key_combo "ctrl-alt-t"
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_wait_for_seconds 1
+    # Maximize the window
+    qt_send_key_combo "alt-space"
+    qt_send_key "x"
+    qt_wait_for_seconds 1
+    # Put something vaguely interesting useful in the terminal
+    qt_send_string_return "xrandr"
+    qt_send_string_return "lsb_release -a"
+    qt_send_string_return "uname -a"
+    qt_wait_for_seconds 1
+    # Get a pretty screenshot
+    qt_screenshot_ppm "$FUNCNAME"
+    # Close the terminal
+    qt_send_key_combo "ctrl-shift-q"
+}
+
+function test_launch_firefox {
+    # Launch Firefox
+    qt_send_key_combo "meta_l"
+    qt_send_string_return "firefox"
+    qt_wait_for_text "$FUNCNAME" "$text_firefox_welcome_to_firefox" 10 5
+    qt_send_key_combo "alt-f4"
+}
+
+function test_power_off_vm() {
+    # send power off
+    qt_poweroff_vm
+}
+
+function test_boot_to_live_environment() {
+    test_setup
+    test_post_boot_grub
+    test_installer_initial_load
+    test_open_terminal_capture_xrandr
+    test_launch_firefox
+    test_power_off_vm
+}

--- a/testcases/ubuntu/24.04/i18n/en_US
+++ b/testcases/ubuntu/24.04/i18n/en_US
@@ -51,6 +51,8 @@ text_installation_select_your_timezone_title="Select your timezone"
 
 text_installation_ready_to_install_title="Ready to install"
 
+text_firefox_welcome_to_firefox="Welcome to Firefox"
+
 # Installation finished screen
 
 text_installation_complete_title="Installation complete"

--- a/testcases/ubuntu/24.04/test_boot_to_live_environment
+++ b/testcases/ubuntu/24.04/test_boot_to_live_environment
@@ -40,9 +40,6 @@ function test_open_terminal_capture_xrandr() {
     qt_send_key_combo "ctrl-alt-t"
     qt_screenshot_ppm "$FUNCNAME"
     qt_wait_for_seconds 1
-    # Maximize the window
-    qt_send_key_combo "meta_l-up"
-    qt_wait_for_seconds 1
     qt_send_string_return "xrandr"
     qt_screenshot_ppm "$FUNCNAME"
     # Get a pretty screenshot

--- a/testcases/ubuntu/24.04/test_boot_to_live_environment
+++ b/testcases/ubuntu/24.04/test_boot_to_live_environment
@@ -1,0 +1,74 @@
+# Boot to live environment
+########################################################################################
+#                                                                                      #
+#        Name: test_boot_to_live_environment                                           #
+#      Author: Alan Pope                                                               #
+#        Date: 2024-05-13                                                              #
+#     Version: 1                                                                       #
+# Description: Boot to the graphical desktop                                           #
+#                                                                                      #
+########################################################################################
+
+function test_setup() {
+    # No setup required
+    echo "No setup required"
+}
+
+function test_post_boot_grub() {
+    # Wait a while for EUFI or BIOS to pass
+    # We could skip having this function, but it's nice to have
+    # So we have the opportunity to click that stupid dialog
+    qt_wait_for_seconds 10
+    # Wait for the grub menu
+    qt_wait_for_text "$FUNCNAME" "$text_console_gnu_grub" 10 5
+    qt_screenshot_ppm "$FUNCNAME"
+    # Press enter on the 'Try or install Ubuntu' GRUB option
+    qt_send_key "return"
+}
+
+function test_installer_initial_load() {
+    # Wait for the installer to load
+    # Takes a while initially to get started so we give it 10 loads of 30 seconds
+    qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_title" 10 30
+    qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_body" 10 3
+    qt_send_key_combo "alt-f4"
+}
+
+## This is temporary for debugging
+function test_open_terminal_capture_xrandr() {
+    # Open a terminal
+    qt_send_key_combo "ctrl-alt-t"
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_wait_for_seconds 1
+    # Maximize the window
+    qt_send_key_combo "meta_l-up"
+    qt_wait_for_seconds 1
+    qt_send_string_return "xrandr"
+    qt_screenshot_ppm "$FUNCNAME"
+    # Get a pretty screenshot
+    qt_screenshot_ppm "$FUNCNAME"
+    # Close the terminal
+    qt_send_key_combo "ctrl-shift-q"
+}
+
+function test_launch_firefox {
+    # Launch Firefox
+    qt_send_key_combo "meta_l"
+    qt_send_string_return "firefox"
+    qt_wait_for_text "$FUNCNAME" "$text_firefox_welcome_to_firefox" 10 5
+    qt_send_key_combo "alt-f4"
+}
+
+function test_power_off_vm() {
+    # send power off
+    qt_poweroff_vm
+}
+
+function test_boot_to_live_environment() {
+    test_setup
+    test_post_boot_grub
+    test_installer_initial_load
+    test_open_terminal_capture_xrandr
+    test_launch_firefox    
+    test_power_off_vm
+}

--- a/testcases/ubuntu/daily-live/i18n/en_US
+++ b/testcases/ubuntu/daily-live/i18n/en_US
@@ -56,6 +56,8 @@ text_installation_select_your_timezone_title="Select your timezone"
 
 text_installation_ready_to_install_title="Ready to install"
 
+text_firefox_welcome_to_firefox="Welcome to Firefox"
+
 # Installation finished screen
 
 text_installation_complete_title="Installation complete"

--- a/testcases/ubuntu/daily-live/test_boot_to_live_environment
+++ b/testcases/ubuntu/daily-live/test_boot_to_live_environment
@@ -1,0 +1,77 @@
+# Boot to welcome screen
+########################################################################################
+#                                                                                      #
+#        Name: test_boot_to_welcome_screen                                             #
+#      Author: Alan Pope                                                               #
+#        Date: 2024-05-13                                                              #
+#     Version: 1                                                                       #
+# Description: Boot to the graphical installer                                         #
+#                                                                                      #
+########################################################################################
+
+function test_setup() {
+    # No setup required
+    echo "No setup required"
+}
+
+function test_post_boot_grub() {
+    # Wait a while for EUFI or BIOS to pass
+    # We could skip having this function, but it's nice to have
+    # So we have the opportunity to click that stupid dialog
+    qt_wait_for_seconds 10
+    # Wait for the grub menu
+    qt_wait_for_text "$FUNCNAME" "$text_console_gnu_grub" 5 5
+    qt_screenshot_ppm "$FUNCNAME"
+    # Press enter on the 'Try or install Ubuntu' GRUB option
+    qt_send_key "return"
+}
+
+function test_installer_initial_load() {
+    # Wait for the installer to load
+    # Takes a while initially to get started so we give it 10 loads of 30 seconds
+    qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_title" 10 30
+    qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_body" 10 3
+    qt_send_key_combo "alt-f4"
+    qt_wait_for_seconds 1
+}
+
+function test_open_terminal_capture_xrandr() {
+    # Open a terminal
+    qt_send_key_combo "ctrl-alt-t"
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_wait_for_seconds 1
+    # Maximize the window
+    qt_send_key_combo "meta_l-up"
+    qt_wait_for_seconds 1
+    # Put something vaguely interesting useful in the terminal
+    qt_send_string_return "xrandr"
+    qt_send_string_return "lsb_release -a"
+    qt_send_string_return "uname -a"
+    qt_wait_for_seconds 1
+    # Get a pretty screenshot
+    qt_screenshot_ppm "$FUNCNAME"
+    # Close the terminal
+    qt_send_key_combo "ctrl-d"
+}
+
+function test_launch_firefox {
+    # Launch Firefox
+    qt_send_key_combo "meta_l"
+    qt_send_string_return "firefox"
+    qt_wait_for_text "$FUNCNAME" "$text_firefox_welcome_to_firefox" 10 5
+    qt_send_key_combo "alt-f4"
+}
+
+function test_power_off_vm() {
+    # send power off
+    qt_poweroff_vm
+}
+
+function test_boot_to_live_environment() {
+    test_setup
+    test_post_boot_grub
+    test_installer_initial_load
+    test_open_terminal_capture_xrandr
+    test_launch_firefox
+    test_power_off_vm
+}

--- a/testcases/ubuntu/daily-live/test_boot_to_live_environment
+++ b/testcases/ubuntu/daily-live/test_boot_to_live_environment
@@ -40,9 +40,6 @@ function test_open_terminal_capture_xrandr() {
     qt_send_key_combo "ctrl-alt-t"
     qt_screenshot_ppm "$FUNCNAME"
     qt_wait_for_seconds 1
-    # Maximize the window
-    qt_send_key_combo "meta_l-up"
-    qt_wait_for_seconds 1
     # Put something vaguely interesting useful in the terminal
     qt_send_string_return "xrandr"
     qt_send_string_return "lsb_release -a"


### PR DESCRIPTION
This adds four identical tests for Ubuntu 24.04 and daily-live, and Ubuntu MATE 24.04 and daily-live.

It starts the VM, waits for the installer to appear, then closes it, and runs a couple of simple commands in a terminal, then launches Firefox. The goal is to do the bare minimum to show the live environment working. 

Additional simple tests could easily be added to these test cases :pray:  - this is the bare minimum to prove the live ISO works.

Here's Ubuntu MATE 24.04 running the tests:


https://github.com/quickemu-project/quicktest/assets/1841272/6b84f3d6-747a-4620-8473-ad5fa7a7113d

[quicktest.log](https://github.com/quickemu-project/quicktest/files/15311925/quicktest.log)


Here's Ubuntu 24.04 running them:


https://github.com/quickemu-project/quicktest/assets/1841272/da81fbe7-75b0-4338-90cc-eb15d9dc634a

[quicktest.log](https://github.com/quickemu-project/quicktest/files/15311917/quicktest.log)


