### PR TITLE
fix: Update boot to live with a few delays

### DIFF
--- a/testcases/ubuntu/24.04/test_boot_to_live_environment
+++ b/testcases/ubuntu/24.04/test_boot_to_live_environment
@@ -1,11 +1,11 @@
-# Boot to live environment
+# Boot to welcome screen
 ########################################################################################
 #                                                                                      #
-#        Name: test_boot_to_live_environment                                           #
+#        Name: test_boot_to_live_environment                                             #
 #      Author: Alan Pope                                                               #
-#        Date: 2024-05-13                                                              #
-#     Version: 1                                                                       #
-# Description: Boot to the graphical desktop                                           #
+#        Date: 2024-05-19                                                              #
+#     Version: 2                                                                       #
+# Description: Boot to the graphical desktop                                        #
 #                                                                                      #
 ########################################################################################
 
@@ -32,9 +32,9 @@ function test_installer_initial_load() {
     qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_title" 10 30
     qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_body" 10 3
     qt_send_key_combo "alt-f4"
+    qt_wait_for_seconds 1
 }
 
-## This is temporary for debugging
 function test_open_terminal_capture_xrandr() {
     # Open a terminal
     qt_send_key_combo "ctrl-alt-t"
@@ -51,9 +51,12 @@ function test_open_terminal_capture_xrandr() {
 function test_launch_firefox {
     # Launch Firefox
     qt_send_key_combo "meta_l"
+    qt_wait_for_seconds 1
     qt_send_string_return "firefox"
     qt_wait_for_text "$FUNCNAME" "$text_firefox_welcome_to_firefox" 10 5
+    qt_wait_for_seconds 1
     qt_send_key_combo "alt-f4"
+    qt_wait_for_seconds 1
 }
 
 function test_power_off_vm() {

--- a/testcases/ubuntu/daily-live/test_boot_to_live_environment
+++ b/testcases/ubuntu/daily-live/test_boot_to_live_environment
@@ -1,11 +1,11 @@
 # Boot to welcome screen
 ########################################################################################
 #                                                                                      #
-#        Name: test_boot_to_welcome_screen                                             #
+#        Name: test_boot_to_live_environment                                             #
 #      Author: Alan Pope                                                               #
-#        Date: 2024-05-13                                                              #
-#     Version: 1                                                                       #
-# Description: Boot to the graphical installer                                         #
+#        Date: 2024-05-19                                                              #
+#     Version: 2                                                                       #
+# Description: Boot to the graphical desktop                                        #
 #                                                                                      #
 ########################################################################################
 
@@ -20,7 +20,7 @@ function test_post_boot_grub() {
     # So we have the opportunity to click that stupid dialog
     qt_wait_for_seconds 10
     # Wait for the grub menu
-    qt_wait_for_text "$FUNCNAME" "$text_console_gnu_grub" 5 5
+    qt_wait_for_text "$FUNCNAME" "$text_console_gnu_grub" 10 5
     qt_screenshot_ppm "$FUNCNAME"
     # Press enter on the 'Try or install Ubuntu' GRUB option
     qt_send_key "return"
@@ -40,23 +40,23 @@ function test_open_terminal_capture_xrandr() {
     qt_send_key_combo "ctrl-alt-t"
     qt_screenshot_ppm "$FUNCNAME"
     qt_wait_for_seconds 1
-    # Put something vaguely interesting useful in the terminal
     qt_send_string_return "xrandr"
-    qt_send_string_return "lsb_release -a"
-    qt_send_string_return "uname -a"
-    qt_wait_for_seconds 1
+    qt_screenshot_ppm "$FUNCNAME"
     # Get a pretty screenshot
     qt_screenshot_ppm "$FUNCNAME"
     # Close the terminal
-    qt_send_key_combo "ctrl-d"
+    qt_send_key_combo "ctrl-shift-q"
 }
 
 function test_launch_firefox {
     # Launch Firefox
     qt_send_key_combo "meta_l"
+    qt_wait_for_seconds 1
     qt_send_string_return "firefox"
     qt_wait_for_text "$FUNCNAME" "$text_firefox_welcome_to_firefox" 10 5
+    qt_wait_for_seconds 1
     qt_send_key_combo "alt-f4"
+    qt_wait_for_seconds 1
 }
 
 function test_power_off_vm() {
@@ -69,6 +69,6 @@ function test_boot_to_live_environment() {
     test_post_boot_grub
     test_installer_initial_load
     test_open_terminal_capture_xrandr
-    test_launch_firefox
+    test_launch_firefox    
     test_power_off_vm
 }


### PR DESCRIPTION
Just added a few delays as sometimes the test gets ahead of itself. For example it will miss the x of 'xrandr' as the window isn't ready to receive input when qemu hits the keys.