### PR TITLE
feat: Move banner to a function. fixes #24

### DIFF
--- a/quicktest
+++ b/quicktest
@@ -670,8 +670,6 @@ function qt_load_keys() {
 # Here we actually launch the test case. 
 function qt_launch_testcase() {
     qt_echo "🚀 Launch test case ${OS}/${RELEASE}${EDITIONPATH}/${TESTCASE}"
-    # Display the first ten lines if they start with a comment
-    head -n 10 "${QT_TESTCASES_DIR}"/"${OS}"/"${RELEASE}${EDITIONPATH}"/"${TESTCASE}" | grep "^#"
     "$TESTCASE"
 }
 

--- a/testcases/alpine/v3.11/test_boot_to_login
+++ b/testcases/alpine/v3.11/test_boot_to_login
@@ -1,13 +1,16 @@
 # Test we can boot to the login screen and login and out then shutdown
-########################################################################################
-#                                                                                      #
-#        Name: test_boot_to_login                                                      #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-10                                                              #
-#     Version: 1                                                                       #
-# Description: A very simple test using a small distro to prove everything works       #
-#                                                                                      #
-########################################################################################
+
+function test_description() {
+    cat << EOF
+A very simple test using a small distro to prove everything works
+- Wait for GNU GRUB
+- Wait for the console login screen
+- Login as root
+- Clear the screen
+- Type all the keys
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     test_alpine_username="root"
@@ -68,3 +71,5 @@ function test_boot_to_login() {
     test_console_logout_user
     test_power_off_vm
 }
+
+test_description

--- a/testcases/alpine/v3.19/test_boot_to_login
+++ b/testcases/alpine/v3.19/test_boot_to_login
@@ -1,13 +1,16 @@
 # Test we can boot to the login screen and login and out then shutdown
-########################################################################################
-#                                                                                      #
-#        Name: test_boot_to_login                                                      #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-10                                                              #
-#     Version: 1                                                                       #
-# Description: A very simple test using a small distro to prove everything works       #
-#                                                                                      #
-########################################################################################
+
+function test_description() {
+    cat << EOF
+A very simple test using a small distro to prove everything works
+- Wait for GNU GRUB
+- Wait for the console login screen
+- Login as root
+- Clear the screen
+- Type all the keys
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     test_alpine_username="root"
@@ -68,3 +71,5 @@ function test_boot_to_login() {
     test_console_logout_user
     test_power_off_vm
 }
+
+test_description

--- a/testcases/kubuntu/daily-live/test_install_calamares_defaults
+++ b/testcases/kubuntu/daily-live/test_install_calamares_defaults
@@ -1,13 +1,14 @@
 # Install Kubuntu daily live (oracular) using defaults
-########################################################################################
-#                                                                                      #
-#        Name: test_install_calamares_defaults                                         #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-10                                                              #
-#     Version: 1                                                                       #
-# Description: Do a clean install of Kubuntu 24.10 using all the defaults              #
-#                                                                                      #
-########################################################################################
+
+function test_description() {
+    cat << EOF
+Do a clean install of Kubuntu 24.10 using all the defaults
+- Wait for GNU GRUB
+- Wait for the 'try or install' screen
+- Go through the installer using all the defaults
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     test_user="Lola Chang"
@@ -128,3 +129,6 @@ function test_install_calamares_defaults() {
     test_installer_wait_for_installation_medium
     test_power_off_vm
 }
+
+test_description
+

--- a/testcases/ubuntu-mate/24.04/test_boot_to_live_environment
+++ b/testcases/ubuntu-mate/24.04/test_boot_to_live_environment
@@ -1,13 +1,15 @@
-# Boot to live environment
-########################################################################################
-#                                                                                      #
-#        Name: test_boot_to_live_environment                                           #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-13                                                              #
-#     Version: 1                                                                       #
-# Description: Boot to the graphical desktop                                           #
-#                                                                                      #
-########################################################################################
+# Boot to the desktop, run a few things and shutdown
+
+function test_description() {
+    cat << EOF
+Boot to the desktop, run a few things and shutdown
+- Wait for GNU GRUB
+- Wait for the Ubuntu installer, then close it
+- Open a terminal and run xrandr
+- Launch Firefox
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     # No setup required
@@ -72,3 +74,5 @@ function test_boot_to_live_environment() {
     test_launch_firefox
     test_power_off_vm
 }
+
+test_description

--- a/testcases/ubuntu-mate/24.04/test_install_entire_disk_with_defaults
+++ b/testcases/ubuntu-mate/24.04/test_install_entire_disk_with_defaults
@@ -1,13 +1,14 @@
-# Install Ubuntu MATE 24.04 using defaults
-########################################################################################
-#                                                                                      #
-#        Name: test_install_entire_disk_with_defaults                                  #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-10                                                              #
-#     Version: 1                                                                       #
-# Description: Do a clean install of Ubuntu MATE 24.04 using all the default options   #
-#                                                                                      #
-########################################################################################
+# Do a clean install of Ubuntu MATE 24.04 using all the defaults
+
+function test_description() {
+    cat << EOF
+Do a clean install of Ubuntu MATE 24.04 using all the defaults
+- Wait for GNU GRUB
+- Wait for the Ubuntu installer to load
+- Go through the installer using all the defaults
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     # Set the test user and password for the installer
@@ -185,3 +186,5 @@ function test_install_entire_disk_with_defaults() {
 
     test_power_off_vm
 }
+
+test_description

--- a/testcases/ubuntu-mate/daily-live/test_boot_to_live_environment
+++ b/testcases/ubuntu-mate/daily-live/test_boot_to_live_environment
@@ -1,13 +1,15 @@
-# Boot to live environment
-########################################################################################
-#                                                                                      #
-#        Name: test_boot_to_live_environment                                           #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-13                                                              #
-#     Version: 1                                                                       #
-# Description: Boot to the graphical desktop                                           #
-#                                                                                      #
-########################################################################################
+# Boot to the desktop, run a few things and shutdown
+
+function test_description() {
+    cat << EOF
+Boot to the desktop, run a few things and shutdown
+- Wait for GNU GRUB
+- Wait for the Ubuntu installer, then close it
+- Open a terminal and run xrandr
+- Launch Firefox
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     # No setup required
@@ -72,3 +74,5 @@ function test_boot_to_live_environment() {
     test_launch_firefox
     test_power_off_vm
 }
+
+test_description

--- a/testcases/ubuntu-mate/daily-live/test_install_entire_disk_with_defaults
+++ b/testcases/ubuntu-mate/daily-live/test_install_entire_disk_with_defaults
@@ -1,13 +1,14 @@
-# Install Ubuntu MATE daily live (oracular) using defaults
-########################################################################################
-#                                                                                      #
-#        Name: test_install_entire_disk_with_defaults                                  #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-10                                                              #
-#     Version: 1                                                                       #
-# Description: Do a clean install of Ubuntu MATE 24.10 using all the default options   #
-#                                                                                      #
-########################################################################################
+# Do a clean install of Ubuntu MATE 24.10 (oracular) using all the defaults
+
+function test_description() {
+    cat << EOF
+Do a clean install of Ubuntu MATE 24.10 (oracular) using all the defaults
+- Wait for GNU GRUB
+- Wait for the Ubuntu installer to load
+- Go through the installer using all the defaults
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     # Set the test user and password for the installer
@@ -185,3 +186,5 @@ function test_install_entire_disk_with_defaults() {
 
     test_power_off_vm
 }
+
+test_description

--- a/testcases/ubuntu/24.04/test_boot_to_live_environment
+++ b/testcases/ubuntu/24.04/test_boot_to_live_environment
@@ -1,13 +1,15 @@
-# Boot to welcome screen
-########################################################################################
-#                                                                                      #
-#        Name: test_boot_to_live_environment                                             #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-19                                                              #
-#     Version: 2                                                                       #
-# Description: Boot to the graphical desktop                                        #
-#                                                                                      #
-########################################################################################
+# Boot to the desktop, run a few things and shutdown
+
+function test_description() {
+    cat << EOF
+Boot to the desktop, run a few things and shutdown
+- Wait for GNU GRUB
+- Wait for the Ubuntu installer, then close it
+- Open a terminal and run xrandr
+- Launch Firefox
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     # No setup required
@@ -72,3 +74,5 @@ function test_boot_to_live_environment() {
     test_launch_firefox    
     test_power_off_vm
 }
+
+test_description

--- a/testcases/ubuntu/24.04/test_install_entire_disk_with_defaults
+++ b/testcases/ubuntu/24.04/test_install_entire_disk_with_defaults
@@ -1,13 +1,14 @@
-# Install Ubuntu 24.04 using defaults
-########################################################################################
-#                                                                                      #
-#        Name: test_install_entire_disk_with_defaults                                  #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-10                                                              #
-#     Version: 1                                                                       #
-# Description: Do a clean install of Ubuntu 24.04 using all the default                #
-#                                                                                      #
-########################################################################################
+# Do a clean install of Ubuntu 24.04 using all the defaults
+
+function test_description() {
+    cat << EOF
+Do a clean install of Ubuntu 24.04 using all the defaults
+- Wait for GNU GRUB
+- Wait for the Ubuntu installer to load
+- Go through the installer using all the defaults
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     # Set the test user and password for the installer
@@ -52,26 +53,6 @@ function test_installer_initial_load() {
             qt_send_key "return"
             ;;
     esac
-}
-
-## This is temporary for debugging
-function test_open_terminal_capture_xrandr() {
-    # Open a terminal
-    qt_send_key_combo "ctrl-alt-t"
-    qt_screenshot_ppm "$FUNCNAME"
-    qt_wait_for_seconds 1
-    # Maximize the window
-    qt_send_key_combo "meta_l-up"
-    qt_wait_for_seconds 1
-    qt_send_string_return "sudo dmidecode"
-    qt_screenshot_ppm "$FUNCNAME"
-    qt_send_key_combo "ctrl-l"
-    qt_send_string_return "xrandr"
-    qt_screenshot_ppm "$FUNCNAME"
-    # Get a pretty screenshot
-    qt_screenshot_ppm "$FUNCNAME"
-    # Close the terminal
-    qt_send_key_combo "ctrl-shift-q"
 }
 
 function test_installer_accessibility_screen() {
@@ -229,3 +210,5 @@ function test_install_entire_disk_with_defaults() {
 
     test_power_off_vm
 }
+
+test_description

--- a/testcases/ubuntu/24.04/test_post_install_clean_first_run
+++ b/testcases/ubuntu/24.04/test_post_install_clean_first_run
@@ -1,18 +1,17 @@
-# Post install first-run test
-########################################################################################
-#                                                                                      #
-#        Name: test_post_install_clean_first_run                                       #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-16                                                              #
-#     Version: 1                                                                       #
-# Description: Test the first-run experience after an installation has been done       #
-#                                                                                      #
-########################################################################################
+# Test the first-run experience after an installation can be completed 
 
+function test_description() {
+    cat << EOF
+Test the first-run experience after an installation can be completed
+- Wait for the GDM3 login screen
+- Log in using the account previously created
+- Wait for the desktop to load
+- Click through the first-run experience
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
-    # Settings we choose to override here
-    KEEP_SCREENSHOTS=true
     # Don't warn us that the disk isn't clean. We expect that in
     # this test
     DISABLE_DISK_WARNING=true
@@ -130,3 +129,5 @@ function test_post_install_clean_first_run() {
     test_desktop_post_install_first_run
     test_desktop_post_install_settings_about
 }
+
+test_description

--- a/testcases/ubuntu/daily-live/test_boot_to_live_environment
+++ b/testcases/ubuntu/daily-live/test_boot_to_live_environment
@@ -1,13 +1,15 @@
-# Boot to welcome screen
-########################################################################################
-#                                                                                      #
-#        Name: test_boot_to_live_environment                                             #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-19                                                              #
-#     Version: 2                                                                       #
-# Description: Boot to the graphical desktop                                        #
-#                                                                                      #
-########################################################################################
+# Boot to the desktop, run a few things and shutdown
+
+function test_description() {
+    cat << EOF
+Boot to the desktop, run a few things and shutdown
+- Wait for GNU GRUB
+- Wait for the Ubuntu installer, then close it
+- Open a terminal and run xrandr
+- Launch Firefox
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     # No setup required
@@ -72,3 +74,5 @@ function test_boot_to_live_environment() {
     test_launch_firefox    
     test_power_off_vm
 }
+
+test_description

--- a/testcases/ubuntu/daily-live/test_install_entire_disk_with_defaults
+++ b/testcases/ubuntu/daily-live/test_install_entire_disk_with_defaults
@@ -1,13 +1,14 @@
-# Install Ubuntu daily live (oracular) using defaults
-########################################################################################
-#                                                                                      #
-#        Name: test_install_entire_disk_with_defaults                                  #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-10                                                              #
-#     Version: 1                                                                       #
-# Description: Do a clean install of Ubuntu 24.10 using all the defaults               #
-#                                                                                      #
-########################################################################################
+# Do a clean install of Ubuntu 24.10 (oracular) using all the defaults
+
+function test_description() {
+    cat << EOF
+Do a clean install of Ubuntu 24.10 (oracular) using all the defaults
+- Wait for GNU GRUB
+- Wait for the Ubuntu installer to load
+- Go through the installer using all the defaults
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     # Set the test user and password for the installer
@@ -230,3 +231,5 @@ function test_install_entire_disk_with_defaults() {
 
     test_power_off_vm
 }
+
+test_description

--- a/testcases/ubuntu/daily-live/test_install_entire_disk_with_defaults_fde
+++ b/testcases/ubuntu/daily-live/test_install_entire_disk_with_defaults_fde
@@ -1,13 +1,14 @@
-# Install Ubuntu daily live (oracular) using defaults and encryption
-########################################################################################
-#                                                                                      #
-#        Name: test_install_entire_disk_with_defaults                                  #
-#      Author: Alan Pope                                                               #
-#        Date: 2024-05-13                                                              #
-#     Version: 1                                                                       #
-# Description: Do a clean install of Ubuntu 24.10 using all the defaults               #
-#              and encyption                                                           #
-########################################################################################
+# Do a clean install of Ubuntu 24.10 (oracular) using all the defaults and encryption
+
+function test_description() {
+    cat << EOF
+Do a clean install of Ubuntu 24.10 (oracular) using all the defaults and encryption
+- Wait for GNU GRUB
+- Wait for the Ubuntu installer to load
+- Go through the installer using all the defaults and full disk encryption
+- Power off the VM at the end
+EOF
+}
 
 function test_setup() {
     # Set the test user and password for the installer
@@ -340,3 +341,5 @@ function test_install_entire_disk_with_defaults_fde() {
 
     # Done
 }
+
+test_description


### PR DESCRIPTION
This moves the description of a test to a `test_description` function. Within that, test authors can display whatever they need to explain the test. They may want to add warnings or informational text about required preparatory steps.

At the end of the test case file, there is a single `test_description` line, which ensures the script prints the description when `source` is run against it.