### PR TITLE
feat: Add test to enable serial console at grub menu

### DIFF
--- a/testcases/ubuntu/24.04/test_boot_to_live_environment_with_serial_console
+++ b/testcases/ubuntu/24.04/test_boot_to_live_environment_with_serial_console
@@ -1,0 +1,96 @@
+# Boot to the desktop, run a few things and shutdown
+
+function test_description() {
+    cat << EOF
+Boot to the desktop, run a few things and shutdown
+- Wait for GNU GRUB
+- Wait for the Ubuntu installer, then close it
+- Open a terminal and run xrandr
+- Launch Firefox
+- Power off the VM at the end
+EOF
+}
+
+function test_setup() {
+    # No setup required
+    echo "No setup required"
+}
+
+function test_post_boot_grub() {
+    # Wait a while for EUFI or BIOS to pass
+    # We could skip having this function, but it's nice to have
+    # So we have the opportunity to click that stupid dialog
+    qt_wait_for_seconds 10
+    # Wait for the grub menu
+    qt_wait_for_text "$FUNCNAME" "$text_console_gnu_grub" 10 5
+    # Edit kernel command line to enable serial console
+    qt_send_key "e"
+    qt_send_key_combo "down"
+    qt_send_key_combo "down"
+    qt_send_key_combo "down"
+    qt_send_key_combo "end"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_key_combo "backspace"
+    qt_send_string "splash console=ttyS0,115200"
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_send_key_combo "f10"
+}
+
+function test_installer_initial_load() {
+    # Wait for the installer to load
+    # Takes a while initially to get started so we give it 10 loads of 30 seconds
+    qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_title" 10 30
+    qt_wait_for_text "$FUNCNAME" "$text_installation_welcome_to_ubuntu_body" 10 3
+    qt_send_key_combo "alt-f4"
+    qt_wait_for_seconds 1
+}
+
+function test_open_terminal_capture_xrandr() {
+    # Open a terminal
+    qt_send_key_combo "ctrl-alt-t"
+    qt_screenshot_ppm "$FUNCNAME"
+    qt_wait_for_seconds 1
+    qt_send_string_return "xrandr"
+    qt_screenshot_ppm "$FUNCNAME"
+    # Get a pretty screenshot
+    qt_screenshot_ppm "$FUNCNAME"
+    # Close the terminal
+    qt_send_key_combo "ctrl-shift-q"
+}
+
+function test_launch_firefox {
+    # Launch Firefox
+    qt_send_key_combo "meta_l"
+    qt_wait_for_seconds 1
+    qt_send_string_return "firefox"
+    qt_wait_for_text "$FUNCNAME" "$text_firefox_welcome_to_firefox" 10 5
+    qt_wait_for_seconds 1
+    qt_send_key_combo "alt-f4"
+    qt_wait_for_seconds 1
+}
+
+function test_power_off_vm() {
+    # send power off
+    qt_poweroff_vm
+}
+
+function test_boot_to_live_environment_with_serial_console() {
+    test_setup
+    test_post_boot_grub
+    test_installer_initial_load
+    test_open_terminal_capture_xrandr
+    test_launch_firefox    
+    test_power_off_vm
+}
+
+test_description


### PR DESCRIPTION
After starting the test, connect to it by running:

    socat -,echo=0,icanon=0 unix-connect:machines/ubuntu-24.04/ubuntu-24.04-serial.socket